### PR TITLE
Fix for vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "mapnik": "https://s3.amazonaws.com/cartodb-node-binary/mapnik/v1.4.15-cdb10/1.4.15-cdb10.tgz",
         "queue-async": "~1.0.7",
         "redis-mpool": "~0.4.0",
-        "request": "2.62.0",
+        "request": "2.74.0",
         "semver": "~5.0.3",
         "sphericalmercator": "1.0.3",
         "step": "~0.0.6",


### PR DESCRIPTION
Windshaft currently has a 1 vulnerable dependency paths, introducing 1 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/CartoDB/Windshaft) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Team
